### PR TITLE
Fix floating title bar height in custom styles sensitive to browser v…

### DIFF
--- a/styles/prosilver/theme/css/style.css
+++ b/styles/prosilver/theme/css/style.css
@@ -31,7 +31,7 @@
 	border-radius: 3px;
 	font-size: 80%;
 	font-weight: bold;
-	height: 100%;
+	height: 1.8em; /* was 100% - fixes custom styles sensitive to browser variabilities  */
 }
 
 .spoiler .spoiler-body {


### PR DESCRIPTION
Fix floating title bar height in custom styles sensitive to browser variabilities.  Sets height according to button and allows multiline titles.  Thanks to @MacFife for fix.