### PR TITLE
Run Travis CI tests under Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 sudo: required
 
 matrix:


### PR DESCRIPTION
They were running under Xenial, and it no longer auto-starts the services like MySQL or PostgreSQL.