### PR TITLE
Use phpBB's service to remove spoilers from descriptions

### DIFF
--- a/includes/helper.php
+++ b/includes/helper.php
@@ -413,25 +413,8 @@ class helper
 			return '';
 		}
 
-		$dom = new \DOMDocument;
-		$dom->preserveWhiteSpace = false;
-		$dom->loadXML($description);
-		$xpath = new \DOMXPath($dom);
-
-		// Remove spoilers
-		foreach ($xpath->query('//SPOILER') as $node)
-		{
-			if (empty($node->nodeType) || empty($node->parentNode))
-			{
-				continue;
-			}
-
-			$node->parentNode->removeChild($node);
-		}
-
-		$description = $dom->saveXML($dom->documentElement);
-
-		return $description;
+		// Remove spoilers at any depth
+		return $this->utils->remove_bbcode($description, 'SPOILER', 0);
 	}
 
 	/**


### PR DESCRIPTION
It looks like this part of the helper can be replaced with phpBB's default service. I can't run the extension's tests at the moment so please let me know if that's not the case.

A couple of notes:

 - You don't really have to test whether `$description` is empty because the method that actually removes tags uses [a string-based test to determine whether the tag is present](https://github.com/s9e/TextFormatter/blob/15bfc779bc74760a57faf94b4379d13845e0ded6/src/Utils.php#L84-L89) in XML, so it won't mind if the input isn't valid XML. It doesn't hurt to leave this check in though, that's why I didn't remove it.

 - Careful with `preserveWhiteSpace`, inter-element whitespace is actually significant in user input. For example, when processing the parsed version of `[b]..[/b] [i]..[/b]` you will lose the space between the two BBCodes.

```php
$dom = new \DOMDocument;
$dom->preserveWhiteSpace = false;
$dom->loadXML('<r><B>..</B> <I>..</I></r>');
echo $dom->saveXML($dom->documentElement);
```
```xml
<r><B>..</B><I>..</I></r>
```