### PR TITLE
Spoiler XSL template improvements

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -85,8 +85,10 @@ class listener implements EventSubscriberInterface
 		}
 
 		// Remove previous definitions
-		unset($configurator->BBCodes[$spoiler['bbcode_tag']]);
-		unset($configurator->tags[$spoiler['bbcode_tag']]);
+		unset(
+			$configurator->BBCodes[$spoiler['bbcode_tag']],
+			$configurator->tags[$spoiler['bbcode_tag']]
+		);
 
 		// Create spoiler BBCode
 		$configurator->BBCodes->addCustom(

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -434,8 +434,12 @@ class helper
 
 		return [
 			'bbcode_tag'	=> 'spoiler',
-			'bbcode_match'	=> '[spoiler title={TEXT2;optional}]{TEXT1}[/spoiler]',
-			'bbcode_tpl'	=> $template
+			'bbcode_match'	=> '[spoiler={PARSE=/(?<title>.+)/} title={TEXT2;optional}]{TEXT1}[/spoiler]',
+			'bbcode_tpl'	=> $template,
+
+			// Kept for backwards compatibility
+			'bbcode_helpline'		=> 'SPOILER_HELPLINE',
+			'display_on_posting'	=> 1
 		];
 	}
 }

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -141,14 +141,7 @@ class helper
 	 */
 	public function uninstall_bbcode()
 	{
-		$data = $this->bbcode_data();
-
-		if (empty($data))
-		{
-			return;
-		}
-
-		$this->remove_bbcode($data['bbcode_tag']);
+		$this->remove_bbcode('spoiler');
 	}
 
 	/**

--- a/styles/all/template/spoiler.xsl
+++ b/styles/all/template/spoiler.xsl
@@ -2,16 +2,6 @@
 	<summary class="spoiler-header">
 		<span class="spoiler-title">
 			<xsl:choose>
-				<xsl:when test="@spoiler and string-length(normalize-space(@spoiler)) > 0">
-					<xsl:choose>
-						<xsl:when test="string-length(normalize-space(@spoiler)) > 140">
-							<xsl:value-of select="concat(normalize-space(substring(normalize-space(@spoiler), 0, 140)), '…')"/>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:value-of select="normalize-space(@spoiler)"/>
-						</xsl:otherwise>
-					</xsl:choose>
-				</xsl:when>
 				<xsl:when test="@title and string-length(normalize-space(@title)) > 0">
 					<xsl:choose>
 						<xsl:when test="string-length(normalize-space(@title)) > 140">


### PR DESCRIPTION
- [x] Extract `title` from `[spoiler="title"]`, which will become `[spoiler title="title"]`
- [x] Add `bbcode_helpline` and `display_on_posting` for backwards compatibility
- [x] Run AutoPrefixer
- [x] Code cleanup